### PR TITLE
Warning message

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,4 @@
+#!/usr/bin/env python3
 import os
 import sys
 import cv2

--- a/main.py
+++ b/main.py
@@ -262,9 +262,15 @@ class main(QtWidgets.QMainWindow):
         '''
         This is for pre-processing
         '''
+
         #Pre_calculate the perfect threshold for glint detection
         self.threshold_range_glint = self.glint_threshold(center_glint, 1, CPI_glint, parameters_glint)
         parameters_glint['threshold'] = self.threshold_range_glint
+
+        print("first pass pass parameters")
+        print(f"  pupil: {parameters_pupil}")
+        print(f"  glint: {parameters_glint}")
+
         #Propress the blurring factor for pupil
         t1 = threading.Thread(target = self.get_blur, args = (4, CPI_pupil, parameters_pupil, ROI_pupil, ROI_glint))
         #Get the count for hough transform
@@ -290,6 +296,11 @@ class main(QtWidgets.QMainWindow):
         #Put in the ideal staring position that might be used in the tracker portion
         parameters_pupil['stare_posi'] = self.stare_posi
         parameters_glint['stare_posi'] = self.stare_posi
+
+        # useful to know for e.g. ./tracker.py
+        print("second pass parameters")
+        print(f"  pupil: {parameters_pupil}")
+        print(f"  glint: {parameters_glint}")
 
         #Create the thread for both pupil and glint
         #No need to join because i don't want the user interface to freeze

--- a/util.py
+++ b/util.py
@@ -1,0 +1,35 @@
+from PyQt5.QtWidgets import QMessageBox
+
+
+def mkmessage(msgtext):
+    """quick message in a box
+    useful for warning user about bad input
+    @param msgtext text to display in messagebox"""
+    msg = QMessageBox()
+    msg.setText(msgtext)
+    msg.show()
+    return msg.exec_()
+
+
+def get_ROI(cropping_factor):
+    '''
+    This one simply cleaer the formatting issues for the cropping factors on the image
+    Another one is CPI which stores [x1, y1, x2, y2]
+    @param cropping_factor [[x1,x2], [y1, y2]]
+    @return ROI like  [x, y, x_displacement, y_displacement]
+    >>> get_ROI([[1, 3], [1, 5]])
+    (1, 1, 2, 4)
+    '''
+    return (cropping_factor[0][0],
+            cropping_factor[1][0],
+            cropping_factor[0][1] - cropping_factor[0][0],
+            cropping_factor[1][1] - cropping_factor[1][0])
+
+
+def get_center(ROI):
+    '''
+    center coordinate using ROI croppig factor
+    >>> get_center([0, 0, 4, 2])
+    (2.0, 1.0)
+    '''
+    return (ROI[0] + ROI[2]/2, ROI[1] + ROI[3]/2)


### PR DESCRIPTION
most notable change is an example of `doctest` testing.
run like `python -m doctest util.py --verbose`

pulled `get_ROI` and `get_center` out of class structure (neither used `self`). added to `util.py` w/doctest in the docstring. Also added the parameter information printing, and dialog box and early return if either pupil or glint roi box has not been selected by the user.

N.B. the `'''` "docstring" typically goes under the function definition. see https://www.python.org/dev/peps/pep-0257/

also `@param` and `@return` are keywords for http://epydoc.sourceforge.net/manual-epytext.html 
but it looks like we should be using restuctured text `:param` style instead 
https://www.sphinx-doc.org/en/master/ 
https://docutils.sourceforge.io/rst.html